### PR TITLE
Revenue across Date Range 

### DIFF
--- a/app/controllers/api/v1/merchants/statistics_controller.rb
+++ b/app/controllers/api/v1/merchants/statistics_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::Merchants::StatisticsController < ApplicationController
-  def index
+  def revenue
     quantity = params[:quantity]
     render json: MerchantSerializer.new(Merchant.most_revenue(quantity))
+  end
+  
+  def items
+    quantity = params[:quantity]
+    render json: MerchantSerializer.new(Merchant.most_items(quantity))
   end
 end

--- a/app/controllers/api/v1/revenue_controller.rb
+++ b/app/controllers/api/v1/revenue_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::RevenueController < ApplicationController
+  def index
+    start_date = params[:start]
+    end_date = params[:end]
+    render json: RevenueSerializer.new(RevenueFacade.total_revenue(start_date, end_date))
+  end
+end

--- a/app/facades/revenue_facade.rb
+++ b/app/facades/revenue_facade.rb
@@ -1,0 +1,10 @@
+class RevenueFacade
+  def self.total_revenue(start_date, end_date)
+    total = Invoice.joins(:invoice_items, :transactions)
+                   .merge(Transaction.unscoped.successful)
+                   .merge(Invoice.unscoped.successful)
+                   .where(created_at: Date.parse(start_date.to_s).beginning_of_day..Date.parse(end_date.to_s).end_of_day)
+                   .sum('invoice_items.quantity * invoice_items.unit_price')
+    Revenue.new(total)
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -29,4 +29,13 @@ class Merchant < ApplicationRecord
       .order('revenue DESC')
       .limit(quantity)
   end
+
+  def self.most_items(quantity)
+    select("merchants.*, SUM(invoice_items.quantity) AS quantity_of_items")
+      .joins(invoices: [:invoice_items, :transactions])
+      .merge(Transaction.unscoped.successful)
+      .merge(Invoice.unscoped.successful)
+      .group(:id).order('quantity_of_items DESC')
+      .limit(quantity)
+  end
 end

--- a/app/poros/revenue.rb
+++ b/app/poros/revenue.rb
@@ -1,0 +1,8 @@
+class Revenue
+  attr_reader :revenue, :id
+
+  def initialize(total)
+    @revenue = total
+    @id = nil
+  end
+end

--- a/app/serializers/revenue_serializer.rb
+++ b/app/serializers/revenue_serializer.rb
@@ -1,0 +1,4 @@
+class RevenueSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :revenue
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       end
       resources :merchants
       resources :items
+      get 'revenue', to: 'revenue#index'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         get '/most_items', to: 'statistics#items'
       end
       namespace :items do
-        get '/:item_id/merchant', to: 'merchant#show'
+        get '/:item_id/merchants', to: 'merchant#show'
         get 'find', to: 'search#show'
         get 'find_all', to: 'search#index'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
         get '/:merchant_id/items', to: 'items#index'
         get 'find', to: 'search#show'
         get 'find_all', to: 'search#index'
-        get '/most_revenue', to: 'statistics#index'
+        get '/most_revenue', to: 'statistics#revenue'
+        get '/most_items', to: 'statistics#items'
       end
       namespace :items do
         get '/:item_id/merchant', to: 'merchant#show'

--- a/spec/requests/api/v1/items/relationship_request_spec.rb
+++ b/spec/requests/api/v1/items/relationship_request_spec.rb
@@ -8,7 +8,7 @@ describe "Relationships - return the merchant associated with an item" do
     merchant_2 = create(:merchant)
     item_3 = create(:item, merchant_id: "#{merchant_2.id}")
 
-    get "/api/v1/items/#{item_1.id}/merchant"
+    get "/api/v1/items/#{item_1.id}/merchants"
     expect(response).to be_successful
     merchant = JSON.parse(response.body, symbolize_names: true)[:data]
 
@@ -31,13 +31,13 @@ describe "Relationships - return the merchant associated with an item" do
     expect(merchant[:attributes]).to have_key(:updated_at)
     expect(merchant[:attributes][:updated_at]).to be_a(String)
 
-    get "/api/v1/items/#{item_2.id}/merchant"
+    get "/api/v1/items/#{item_2.id}/merchants"
     expect(response).to be_successful
     merchant = JSON.parse(response.body, symbolize_names: true)[:data]
     expect(merchant[:id]).to eq("#{merchant_1.id}")
     expect(merchant[:id]).to_not eq("#{merchant_2.id}")
 
-    get "/api/v1/items/#{item_3.id}/merchant"
+    get "/api/v1/items/#{item_3.id}/merchants"
     expect(response).to be_successful
     merchant = JSON.parse(response.body, symbolize_names: true)[:data]
     expect(merchant[:id]).to eq("#{merchant_2.id}")

--- a/spec/requests/api/v1/merchants/statistics/merchant_stats_spec.rb
+++ b/spec/requests/api/v1/merchants/statistics/merchant_stats_spec.rb
@@ -135,4 +135,82 @@ describe "Merchant Business Intelligence Endpoints:" do
 
     end
   end
+
+  scenario "returns a variable number of merchants ranked by total number of items sold" do
+    # Experimenting in rails c and rails db, this is what I ended with
+    #
+    # puts Merchant.select("merchants.*, SUM(invoice_items.quantity) AS quantity_of_items").joins(invoices: [:invoice_items, :transactions]).where(transactions: {result: "success"}).where(invoices: {status: "shipped"}).group(:id).order('quantity_of_items DESC').to_sql
+    #
+    # SELECT merchants.*, SUM(invoice_items.quantity) AS quantity_of_items FROM "merchants" INNER JOIN "invoices" ON "invoices"."merchant_id" = "merchants"."id" INNER JOIN "invoice_items" ON "invoice_items"."invoice_id" = "invoices"."id" INNER JOIN "transactions" ON "transactions"."invoice_id" = "invoices"."id" WHERE "transactions"."result" = 'success' AND "invoices"."status" = 'shipped' GROUP BY "merchants"."id" ORDER BY quantity_of_items DESC;
+    #
+    # Merchant Method Creation with updates for scopes that exist
+    #
+    # def self.most_items(quantity)
+    #   select("merchants.*, SUM(invoice_items.quantity) AS quantity_of_items")
+    #     .joins(invoices: [:invoice_items, :transactions])
+    #     .merge(Transaction.unscoped.successful)
+    #     .merge(Invoice.unscoped.successful)
+    #     .group(:id).order('quantity_of_items DESC')
+    #     .limit(quantity)
+    # end
+
+    # Top 2
+    merchant_1 = create(:merchant)
+    merchant_2 = create(:merchant)
+
+    # Bottom 3
+    merchant_3 = create(:merchant)
+    merchant_4 = create(:merchant)
+    merchant_5 = create(:merchant)
+
+    invoice_1 = create(:invoice, merchant_id: merchant_1.id)
+    create(:transaction, result: "success", invoice_id: invoice_1.id)
+    create(:invoice_item, quantity: 20, unit_price: 100.00, invoice_id: invoice_1.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_2 = create(:invoice, merchant_id: merchant_2.id)
+    create(:transaction, result: "success", invoice_id: invoice_2.id)
+    create(:invoice_item, quantity: 15, unit_price: 100.00, invoice_id: invoice_2.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_3 = create(:invoice, merchant_id: merchant_3.id)
+    create(:transaction, result: "success", invoice_id: invoice_3.id)
+    create(:invoice_item, quantity: 10, unit_price: 100.00, invoice_id: invoice_3.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_4 = create(:invoice, merchant_id: merchant_4.id)
+    create(:transaction, result: "success", invoice_id: invoice_4.id)
+    create(:invoice_item, quantity: 5, unit_price: 100.00, invoice_id: invoice_4.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_5 = create(:invoice, merchant_id: merchant_5.id)
+    create(:transaction, result: "success", invoice_id: invoice_5.id)
+    create(:invoice_item, quantity: 1, unit_price: 100.00, invoice_id: invoice_5.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_6 = create(:invoice, merchant_id: merchant_1.id)
+    create(:transaction, result: "failed", invoice_id: invoice_6.id)
+    create(:invoice_item, invoice_id: invoice_6.id)
+
+    invoice_7 = create(:invoice, merchant_id: merchant_2.id)
+    create(:transaction, result: "failed", invoice_id: invoice_7.id)
+    create(:invoice_item, invoice_id: invoice_7.id)
+
+    invoice_8 = create(:invoice, merchant_id: merchant_3.id)
+    create(:transaction, result: "failed", invoice_id: invoice_8.id)
+    create(:invoice_item, invoice_id: invoice_8.id)
+
+    quantity = 2
+    get "/api/v1/merchants/most_items?quantity=#{quantity}"
+
+    expect(response).to be_successful
+    results = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(results.count).to eq(quantity)
+
+    results.each do |result|
+      expect(result[:type]).to eq("merchant")
+
+      expect(result[:id].to_i).to eq(merchant_1.id).or(eq merchant_2.id)
+      expect(result[:id].to_i).to_not eq(merchant_3.id)
+      expect(result[:id].to_i).to_not eq(merchant_4.id)
+      expect(result[:id].to_i).to_not eq(merchant_5.id)
+
+    end
+  end
 end

--- a/spec/requests/api/v1/revenue/revenue_stats_spec.rb
+++ b/spec/requests/api/v1/revenue/revenue_stats_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+describe "Revenue Business Intelligence Endpoints:" do
+  scenario "returns the total revenue across all merchants between the given dates." do
+    # This is not an index or show action, it might be a total action
+    #
+    # Active Record Dreaming
+    #   To get to revenue - merchants to invoices to invoice_items(contains rev calc & where condition) and transactions(contains where condition)
+    #   To select by dates - which table(s) provide a created/updated that we want to call upon
+    #     - I dont think merchants creation helps us
+    #     - Invoice creation? updation?
+    #   After testing in rails c and rails db... do I really need to go through merchants to call the totes revenue? It just needs to be invoice.status="shipped" and transactions.result="success" that can then SUM invoice_items.quantity*invoice_items.unit_price
+    #
+    # Finalized rails c and rails db attempt
+    #   puts Invoice.joins(:invoice_items, :transactions).where(status: "shipped").where(transactions: {result: "success"}).where(created_at: Date.parse('2012-03-21').beginning_of_day..Date.parse('2012-03-27').end_of_day).sum('invoice_items.quantity * invoice_items.unit_price')
+    #
+    #   SELECT SUM(invoice_items.quantity * invoice_items.unit_price) FROM "invoices" INNER JOIN "invoice_items" ON "invoice_items"."invoice_id" = "invoices"."id" INNER JOIN "transactions" ON "transactions"."invoice_id" = "invoices"."id" WHERE "invoices"."status" = $1 AND "transactions"."result" = $2 AND "invoices"."created_at" BETWEEN $3 AND $4  [["status", "shipped"], ["result", "success"], ["created_at", "2012-03-21 00:00:00"], ["created_at", "2012-03-27 23:59:59.999999"]];
+    #
+    # Revenue (This is not a model... is it a PORO?) Method Creation with updates for scope and passed arguments
+    #   def total_revenue(start_date, end_date)
+    #     Invoice.joins(:invoice_items, :transactions)
+    #       .merge(Transaction.unscoped.successful)
+    #       .merge(Invoice.unscoped.successful)
+    #       .where(created_at: Date.parse(start_date.to_s).beginning_of_day..Date.parse(end_date.to_s).end_of_day)
+    #       .sum('invoice_items.quantity * invoice_items.unit_price')
+    #   end
+    #
+    # # FACTORY CREATION
+    #   I need merchants, invoices, invoice_items, and transactions
+    #   I must include unit_prices and quantities so that I can calculate total revenue myself
+    #   Keep it simple and borrow and edit from the merchant statistics spec
+    #     - Make it even simpler and only have 3 total merchants
+    #     - Each merchant only has 2 invoices (with 1 transaction "success" the other "failed")
+    #     - Unit price = 100
+    #     - Quantity = 1
+    #
+    # EXAMPLE JSON RESPONSE FOR SERIALIZER
+    # {
+    #   "data": {
+    #     "id": null,
+    #     "attributes": {
+    #       "revenue"  : 43201227.8000003
+    #     }
+    #   }
+    # }
+
+    merchant_1 = create(:merchant)
+    merchant_2 = create(:merchant)
+    merchant_3 = create(:merchant)
+
+    invoice_1 = create(:invoice, merchant_id: merchant_1.id)
+    create(:transaction, result: "success", invoice_id: invoice_1.id)
+    create(:invoice_item, quantity: 1, unit_price: 100.00, invoice_id: invoice_1.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_2 = create(:invoice, merchant_id: merchant_1.id)
+    create(:transaction, result: "failed", invoice_id: invoice_2.id)
+    create(:invoice_item, quantity: 1, unit_price: 100.00, invoice_id: invoice_2.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_3 = create(:invoice, merchant_id: merchant_2.id)
+    create(:transaction, result: "success", invoice_id: invoice_3.id)
+    create(:invoice_item, quantity: 1, unit_price: 100.00, invoice_id: invoice_3.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_4 = create(:invoice, merchant_id: merchant_2.id)
+    create(:transaction, result: "failed", invoice_id: invoice_4.id)
+    create(:invoice_item, quantity: 1, unit_price: 100.00, invoice_id: invoice_4.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_5 = create(:invoice, merchant_id: merchant_3.id)
+    create(:transaction, result: "success", invoice_id: invoice_5.id)
+    create(:invoice_item, quantity: 1, unit_price: 100.00, invoice_id: invoice_5.id, item_id: create(:item, unit_price: 100.00).id)
+
+    invoice_6 = create(:invoice, merchant_id: merchant_3.id)
+    create(:transaction, result: "failed", invoice_id: invoice_6.id)
+    create(:invoice_item, quantity: 1, unit_price: 100.00, invoice_id: invoice_6.id, item_id: create(:item, unit_price: 100.00).id)
+
+    # Since only 3 invoices are successful
+    # They each bring in 100
+    expected_revenue = 300.00
+
+    # Api and finish the test
+    start_date = '2020-03-09'
+    end_date = '2020-03-24'
+    get "/api/v1/revenue?start=#{start_date}&end=#{end_date}"
+
+    expect(response).to be_successful
+    result = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(result[:id]).to be_null
+    expect(result[:attributes][:revenue]).to eq(expected_revenue)
+  end
+
+  scenario "returns the total revenue for a single merchant" do
+    # This seems like a show action
+  end
+end

--- a/spec/requests/api/v1/revenue/revenue_stats_spec.rb
+++ b/spec/requests/api/v1/revenue/revenue_stats_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "Revenue Business Intelligence Endpoints:" do
   scenario "returns the total revenue across all merchants between the given dates." do
-    # This is not an index or show action, it might be a total action
+    # Since it is a call of total revenue and we have no other calls, except indivual merchant revenue, I think I can label it as INDEX
     #
     # Active Record Dreaming
     #   To get to revenue - merchants to invoices to invoice_items(contains rev calc & where condition) and transactions(contains where condition)
@@ -77,13 +77,13 @@ describe "Revenue Business Intelligence Endpoints:" do
     expected_revenue = 300.00
 
     # Api and finish the test
-    start_date = '2020-03-09'
-    end_date = '2020-03-24'
+    start_date = Date.today
+    end_date = Date.today
     get "/api/v1/revenue?start=#{start_date}&end=#{end_date}"
 
     expect(response).to be_successful
     result = JSON.parse(response.body, symbolize_names: true)[:data]
-    expect(result[:id]).to be_null
+    expect(result[:id]).to be_nil
     expect(result[:attributes][:revenue]).to eq(expected_revenue)
   end
 


### PR DESCRIPTION
## This endpoint should return the total revenue across all merchants between the given dates.

Closes #19 

### Current Issues
- Serializers, Facade, and PORO need tests
- Confused about my json api spec response
- Tech Requirements say:
```json
{
  "data": {
    "id": null,
    "attributes": {
      "revenue"  : 43201227.8000003
    }
  }
}
```
- But Mine is below (and I'm unsure if I can just leave the type in)
```json
{
  "data": {
    "id": null,
    "type": "revenue",
    "attributes": {
      "revenue"  : 43201227.8000003
    }
  }
}
```